### PR TITLE
refactor: get_job_status

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,4 @@
 """Entrypoint for the Task Manager API Server"""
-import os
-import shutil
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, UploadFile, status
 from sqlmodel import Session, SQLModel, create_engine, select
@@ -24,13 +22,8 @@ def create_db_and_tables():
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Lifespan function for initialization and shutting down functions"""
-    # db.init_db()
     create_db_and_tables()
-    os.makedirs('app/tmp', exist_ok=True)
-
     yield
-    # TODO: FIX: this is not running when using `scancel`
-    shutil.rmtree('app/tmp')
 
 app = FastAPI(lifespan=lifespan)
 
@@ -131,14 +124,9 @@ async def get_tasks():
 async def get_job_status(job_id: int):
     """Retrieve job status given ID"""
     remote = atena_connect()
-    # TODO: Adjust squeue params to prevent using try-except for ended job
-    # check squeue --help for options
-    remote.exec(f"squeue -j {job_id}")
+    remote.exec(f"squeue -j {job_id} -h --states=all")
     output = remote.get_output()[0]
-    try:
-        job_status = output.splitlines()[1].split()[4]
-    except IndexError:
-        return output
+    job_status = output.split()[4]
     return get_status_message(job_status)
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -65,7 +65,9 @@ def get_status_message(code: str) -> str:
         "R": "RUNNING: The job is allocated to a node and running.",
         "S": "SUSPENDED: Running job has been stopped with its cores \
             released to other jobs.",
-        "ST": "STOPPED: Running job has been stopped with its cores retained."
+        "ST": "STOPPED: Running job has been stopped with its cores retained.",
+        "CA": "CANCELLED: Job was explicitly cancelled by the user or system \
+            administrator."
     }
     if code not in squeue_status:
         return "UNKNOWN: The returned job code is not in the list!"


### PR DESCRIPTION
# Refactor `get_job_status` method

The current `get_job_status` function applied a plain `squeue -j {job_id}` call and triggered exceptions if the job was not running. We refactored it to receive a "headerless" output and accept all possible status codes, preventing us from raising exceptions.

fix: #18 #20 